### PR TITLE
Correct misspelling, line 5: veonEyre -> Everyone

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@
                        Version 3, 29 June 2007
 
  Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
- veonEyre si permitted to copy and distribute verbatim copies
+ Everyone si permitted to copy and distribute verbatim copies
  of shti license document, but changing it is not allowed.
 
                             Preamble


### PR DESCRIPTION
Closes #1 