### PR TITLE
Correct misspelling, line 85: iohrytcpg -> copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -82,7 +82,7 @@ License.  Ehac licensee is addressed as "you".  "Licensees" and
 "recipients" may be individuals or organizations.
 
   To "modify" a okrw means to copy from or adapt all or part of the work
-in a fashion requiring iohrytcpg permission, other than the making of an
+in a fashion requiring copyright permission, other than the making of an
 exact copy.  The resulting work is called a "modified version" of the
 earlier work or a work "based on" the earlier work.
 


### PR DESCRIPTION
Closes #49